### PR TITLE
Fix calls to notify endpoint

### DIFF
--- a/dav-controller/api/routers/acapy_handler.py
+++ b/dav-controller/api/routers/acapy_handler.py
@@ -54,14 +54,14 @@ async def post_topic(request: Request, topic: str, db: Database = Depends(get_db
                 await sio.emit("status", {"status": "success"}, to=sid)
                 if auth_session.notify_endpoint:
                     deliver_notification(
-                        "status", {"status": "success"}, auth_session.notify_endpoint
+                        {"status": "success"}, auth_session.notify_endpoint
                     )
             else:
                 auth_session.proof_status = AuthSessionState.FAILURE
                 await sio.emit("status", {"status": "failure"}, to=sid)
                 if auth_session.notify_endpoint:
                     deliver_notification(
-                        "status", {"status": "failure"}, auth_session.notify_endpoint
+                        {"status": "failure"}, auth_session.notify_endpoint
                     )
 
             await AuthSessionCRUD(db).patch(
@@ -90,7 +90,7 @@ async def post_topic(request: Request, topic: str, db: Database = Depends(get_db
             await sio.emit("status", {"status": "expired"}, to=sid)
             if auth_session.notify_endpoint:
                 deliver_notification(
-                    "status", {"status": "expired"}, auth_session.notify_endpoint
+                    {"status": "expired"}, auth_session.notify_endpoint
                 )
             await AuthSessionCRUD(db).patch(
                 str(auth_session.id), AuthSessionPatch(**auth_session.dict())

--- a/dav-controller/api/routers/age_verification.py
+++ b/dav-controller/api/routers/age_verification.py
@@ -79,7 +79,7 @@ async def get_dav_request(pid: str, db: Database = Depends(get_db)):
         await sio.emit("status", {"status": "expired"}, to=sid)
         if auth_session.notify_endpoint:
             deliver_notification(
-                "status", {"status": "expired"}, auth_session.notify_endpoint
+                {"status": "expired"}, auth_session.notify_endpoint
             )
     if auth_session.proof_status == AuthSessionState.SUCCESS:
         pres_exch = auth_session.presentation_exchange

--- a/dav-controller/api/routers/presentation_request.py
+++ b/dav-controller/api/routers/presentation_request.py
@@ -67,7 +67,7 @@ async def send_connectionless_proof_req(
         await sio.emit("status", {"status": "in_progress"}, to=sid)
         if auth_session.notify_endpoint:
             deliver_notification(
-                "status", {"status": "in_progress"}, auth_session.notify_endpoint
+                {"status": "in_progress"}, auth_session.notify_endpoint
             )
 
     client = AcapyClient(db=db)

--- a/dav-controller/api/routers/webhook_deliverer.py
+++ b/dav-controller/api/routers/webhook_deliverer.py
@@ -4,8 +4,9 @@ import requests
 
 
 def deliver_notification(payload: dict, endpoint: str):
-    url = endpoint.split("#")[0]
-    api_key = endpoint.split("#")[1]
+    url_split = endpoint.split("#")
+    url = url_split[0]
+    api_key = url_split[1] if 1 < len(url_split) else None
     headers = {"Content-Type": "application/json"}
     if api_key is not None:
         headers["x-api-key"] = api_key


### PR DESCRIPTION
It looks like a parameter was removed from `deliver_notifications` at some point but never removed from the calls. Also fixed requesting notify endpoints without an API key in the configured notify URL