### PR TITLE
Add Caddy as reverse proxy to handle traffic on standard ports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -336,4 +336,7 @@ dav-controller/static/
 dav-controller/signing-keys/
 dav-controller/api/proof_config.yaml
 
+# Reverse Proxy
+**/certs
+
 wallet.txt

--- a/dav-controller/api/core/models.py
+++ b/dav-controller/api/core/models.py
@@ -3,7 +3,6 @@ from typing import TypedDict
 
 from bson import ObjectId
 from pydantic import BaseModel, Field
-from pyop.userinfo import Userinfo
 
 
 class PyObjectId(ObjectId):

--- a/dav-controller/api/routers/quick-socket/app.py
+++ b/dav-controller/api/routers/quick-socket/app.py
@@ -1,51 +1,9 @@
+import socketio  # Installed with 'pip install python-socketio`
 import uvicorn
 from fastapi import FastAPI
-from fastapi.responses import HTMLResponse
-import socketio  # Installed with 'pip install python-socketio`
-
-html = """
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <title>Socket.io Test</title>
-    <script src="https://cdn.socket.io/4.3.2/socket.io.min.js"></script>
-    <script>
-        const socket = io("ws://localhost:5100", {
-        path: "/ws/socket.io",
-        autoConnect: false,
-        });
-
-        const handleConnect = () => {
-            console.log("Button Clicked to Connect");
-            socket.connect();
-        };
-
-        const handleDisconnect = () => {
-            console.log("Button Clicked to Disconnect");
-            socket.disconnect();
-        };
-
-        socket.on("message", (e) => console.log("Received", e));
-    </script>
-</head>
-<body>
-    <div className="App">
-        <button onClick="handleConnect()">Connect</button>
-        <button onClick="handleDisconnect()">Disconnect</button>
-    </div>
-</body>
-</html>
-"""
 
 # Create a FastAPI instance
 app = FastAPI()
-
-
-@app.get("/")
-async def root():
-    return HTMLResponse(html)
-
 
 # Create a test websocket server
 # TODO: This needs to be shared with age_verification.py and acapy_handler.py

--- a/dav-controller/api/templates/verified_credentials.html
+++ b/dav-controller/api/templates/verified_credentials.html
@@ -407,7 +407,7 @@
          * Initialize the Websocket
          */
         this.socket = io(location.host, {
-          path: "/ws/socket.io",
+          path: `${location.pathname}ws/socket.io`,
           autoConnect: false,
         });
  
@@ -436,8 +436,7 @@
          * all other functionality.
          */
         const checkStatus = () => {
-          const host = window.location.origin;
-          const url = host + "{{challenge_poll_uri}}" + "/age-verification/{{pid}}";
+          const url = "age-verification/{{pid}}";
           fetch(url)
             .then((res) => res.json())
             .then((data) => {

--- a/dav-controller/requirements.txt
+++ b/dav-controller/requirements.txt
@@ -1,8 +1,6 @@
 fastapi==0.96.0
 jinja2==3.1.2
-oic==1.6.0
 pymongo==4.3.3
-pyop==3.4.0
 python-multipart==0.0.6 # required by fastapi to serve/upload files
 qrcode[pil]==7.4.2
 structlog==23.1.0
@@ -11,3 +9,4 @@ python-socketio==5.8.0 # required to run websockets
 canonicaljson==2.0.0 # used to provide unique consistent user identifiers
 pyyaml==6.0.1
 cachetools==5.3.3
+requests==2.32.2

--- a/docker/.env-example
+++ b/docker/.env-example
@@ -1,8 +1,10 @@
 COMPOSE_PROJECT_NAME=lcrb-dav
 
 APPLICATION_DOMAIN=<your-domain.test> # replace with your domain
+EMAIL_CONTACT=<yourname@domain.test> # email contact to be used for TLS certificate issuance
+#CA_ENDPOINT=https://acme-v02.api.letsencrypt.org/directory
 
-# Agent Settings
+#Agent Settings
 AGENT_NAME=Digital Age Verification Service
 AGENT_ADMIN_API_KEY=<api-key> # pick a value to secure the agent admin API
 AGENT_WALLET_ENCRYPTION_KEY=<secret> # replace with alphanumeric key to secure wallet
@@ -11,5 +13,5 @@ AGENT_WALLET_SEED=<dav_verifier_0000000000000000000> # replace with a custom see
 #Controller DB settings
 DAV_CONTROLLER_DB_PWD=<secret> # replace with a custom password
 
-# Agent DB settings
+#Agent DB settings
 POSTGRES_PASSWORD=<secret> # replace with a custom password

--- a/docker/.env-example
+++ b/docker/.env-example
@@ -1,21 +1,15 @@
 COMPOSE_PROJECT_NAME=lcrb-dav
 
-#Controller DB settings
-DAV_CONTROLLER_DB_PWD=<pick-your-db-password> # replace with a custom password
-
-#Controller settings
-CONTROLLER_URL=<url-to-reach-the-controller-on-the-network>
-DAV_PROOF_CONFIG_ID=age-verification-bc-person-credential
-CONTROLLER_SERVICE_PORT=5000
-
-# Agent DB settings
-POSTGRES_PASSWORD=<pick-your-db-password> # replace with a custom password
+APPLICATION_DOMAIN=<your-domain.test> # replace with your domain
 
 # Agent Settings
 AGENT_NAME=Digital Age Verification Service
-AGENT_ENDPOINT=<https://your-domain.test> # replace with the exposed URL of the agent
-AGENT_HTTP_PORT=8030
-AGENT_ADMIN_PORT=8077
-AGENT_ADMIN_API_KEY=<pick-your-api-key> # pick a value to secure the agent admin API
-AGENT_WALLET_ENCRYPTION_KEY=<pick-encryption-key> # replace with alphanumeric key to secure wallet
-AGENT_WALLET_SEED=<pick-your-seed> # replace with a custom seed. Seed must be alphanumeric and 32 characters long
+AGENT_ADMIN_API_KEY=<api-key> # pick a value to secure the agent admin API
+AGENT_WALLET_ENCRYPTION_KEY=<secret> # replace with alphanumeric key to secure wallet
+AGENT_WALLET_SEED=<dav_verifier_0000000000000000000> # replace with a custom seed. Seed must be alphanumeric and 32 characters long
+
+#Controller DB settings
+DAV_CONTROLLER_DB_PWD=<secret> # replace with a custom password
+
+# Agent DB settings
+POSTGRES_PASSWORD=<secret> # replace with a custom password

--- a/docker/caddy/Caddyfile
+++ b/docker/caddy/Caddyfile
@@ -46,7 +46,7 @@
             key    {remote_host}
             window 5s
             events 15
-	    }
+        }
     }
 
     # Openly exposed health check endpoint
@@ -62,7 +62,7 @@
     rewrite @spa_router {http.matchers.file.relative}
 
     # Proxy requests to ACA-Py
-    route /agent/* {
+    route /agent {
         uri strip_prefix /agent
         reverse_proxy {$AGENT_HOST}:{$AGENT_PORT} {
             header_up Host {upstream_hostport}

--- a/docker/caddy/Caddyfile
+++ b/docker/caddy/Caddyfile
@@ -3,8 +3,9 @@
 }
 
 {$APPLICATION_DOMAIN} {
-    # Set CA authority - override this for development
-    tls {
+    # Set CA authority - defaults to Letsencrypt Staging
+    # Email contact is used for Letsencrypt certificate communications
+    tls {$EMAIL_CONTACT} {
         ca {$CA_ENDPOINT}
     }
 
@@ -50,6 +51,15 @@
 
     # Openly exposed health check endpoint
     respond /health 200
+
+    # Required for SPA router to work
+    @spa_router {
+        not path /dav/* /agent/*
+        file {
+            try_files {path} /index.html
+        }
+    }
+    rewrite @spa_router {http.matchers.file.relative}
 
     # Proxy requests to ACA-Py
     route /agent/* {

--- a/docker/caddy/Caddyfile
+++ b/docker/caddy/Caddyfile
@@ -1,0 +1,71 @@
+{
+    order rate_limit before basicauth
+}
+
+{$APPLICATION_DOMAIN} {
+    # Set CA authority - override this for development
+    tls {
+        ca {$CA_ENDPOINT}
+    }
+
+    # Most common security headers
+    header {
+        # enable CSP
+        Content-Security-Policy "default-src * data: blob: filesystem: 'unsafe-inline' 'unsafe-eval'";
+        # enable HSTS
+        Strict-Transport-Security "max-age=86400; includeSubDomains";
+        # disable clients from sniffing the media type
+        X-Content-Type-Options "nosniff";
+        # XSS protection
+        X-XSS-Protection 1;
+        # clickjacking protection
+        X-Frame-Options DENY;
+    }
+
+    # Log everything to stdout
+    log {
+        output stdout
+    }
+
+    #  Set server root
+    root * /srv
+
+    # Enable serving static files
+    file_server
+
+    # Enable gzip, zstd compression
+    encode zstd gzip
+
+    # Enable templates module - required for
+    templates
+
+    # Limit request rate to avoid DDoS attacks
+    rate_limit {
+        zone dav {
+            key    {remote_host}
+            window 5s
+            events 15
+	    }
+    }
+
+    # Openly exposed health check endpoint
+    respond /health 200
+
+    # Proxy requests to ACA-Py
+    route /agent/* {
+        uri strip_prefix /agent
+        reverse_proxy {$AGENT_HOST}:{$AGENT_PORT} {
+            header_up Host {upstream_hostport}
+            header_up X-Forwarded-Host {host}
+        }
+    }
+
+    # Proxy requests to Controller
+    route /dav/* {
+        uri strip_prefix /dav
+        reverse_proxy {$CONTROLLER_HOST}:{$CONTROLLER_PORT} {
+            header_up Host {upstream_hostport}
+            header_up X-Forwarded-Host {host}
+        }
+    }
+}

--- a/docker/caddy/Dockerfile
+++ b/docker/caddy/Dockerfile
@@ -1,0 +1,12 @@
+# caddy build stage
+FROM caddy:builder-alpine
+
+# Install ratelimit plugin
+RUN xcaddy build --with github.com/mholt/caddy-ratelimit
+
+# Fix permissions issue with Caddy image
+# - Between version 2.6.2 and 2.6.3 there were some permissions changes on the official images that stopped them from working on OpenShift.
+# - This update resolves that permissions issue for OCP.
+RUN chown 1001:root /usr/bin/caddy
+
+CMD [ "caddy", "run", "--config", "/etc/caddy/Caddyfile", "--adapter", "caddyfile" ]

--- a/docker/docker-compose-prod.yaml
+++ b/docker/docker-compose-prod.yaml
@@ -72,7 +72,7 @@ services:
       - ACAPY_READ_ONLY_LEDGER=true
       - ACAPY_GENESIS_TRANSACTIONS_LIST=/tmp/ledgers.yaml
       - ACAPY_LOG_LEVEL=info
-      - http://controller:5000/webhooks
+      - ACAPY_WEBHOOK_URL=http://controller:5000/webhooks
       - ACAPY_AUTO_PROVISION=true
       - POSTGRESQL_WALLET_HOST=wallet-db
       - POSTGRESQL_WALLET_PORT=5432

--- a/docker/docker-compose-prod.yaml
+++ b/docker/docker-compose-prod.yaml
@@ -13,6 +13,7 @@ services:
       - CA_ENDPOINT=${CA_ENDPOINT:-https://acme-staging-v02.api.letsencrypt.org/directory}
     volumes:
       - ./caddy/Caddyfile:/etc/caddy/Caddyfile
+      - ./caddy/certs:/root/.local/share/caddy/certificates
     ports:
       - ${HTTP_PORT:-80}:80
       - ${HTTPS_PORT:-443}:443
@@ -61,7 +62,7 @@ services:
       - dav_controller
 
   aca-py:
-    image: ghcr.io/hyperledger/aries-cloudagent-python:py3.9-0.11.0
+    image: ghcr.io/hyperledger/aries-cloudagent-python:py3.9-0.12.1
     environment:
       - ACAPY_WALLET_NAME=dav_agent_wallet
       - ACAPY_WALLET_TYPE=askar

--- a/docker/docker-compose-prod.yaml
+++ b/docker/docker-compose-prod.yaml
@@ -40,7 +40,7 @@ services:
       - ST_ACAPY_ADMIN_API_KEY=${AGENT_ADMIN_API_KEY}
       - DAV_CONTROLLER_DB_USER_PWD=${DAV_CONTROLLER_DB_PWD}
       - CONTROLLER_URL=${APPLICATION_DOMAIN}/dav
-      - ACAPY_AGENT_URL=${APPLICATION_DOMAIN}/agent/
+      - ACAPY_AGENT_URL=${APPLICATION_DOMAIN}/agent
     volumes:
       - ../dav-controller:/app:rw
       - ./dav-controller/proof_config_prod.yaml:/app/api/proof_config.yaml

--- a/docker/docker-compose-prod.yaml
+++ b/docker/docker-compose-prod.yaml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   reverse-proxy:
     build:
@@ -10,7 +9,8 @@ services:
       - CONTROLLER_PORT=5000
       - AGENT_HOST=aca-py
       - AGENT_PORT=8030
-      - CA_ENDPOINT=${CA_ENDPOINT:-https://acme-v02.api.letsencrypt.org/directory}
+      - EMAIL_CONTACT=${EMAIL_CONTACT}
+      - CA_ENDPOINT=${CA_ENDPOINT:-https://acme-staging-v02.api.letsencrypt.org/directory}
     volumes:
       - ./caddy/Caddyfile:/etc/caddy/Caddyfile
     ports:
@@ -39,8 +39,8 @@ services:
       - DAV_PROOF_CONFIG_ID=age-verification-bc-person-credential
       - ST_ACAPY_ADMIN_API_KEY=${AGENT_ADMIN_API_KEY}
       - DAV_CONTROLLER_DB_USER_PWD=${DAV_CONTROLLER_DB_PWD}
-      - CONTROLLER_URL=${APPLICATION_DOMAIN}/controller
-      - ACAPY_AGENT_URL=${APPLICATION_DOMAIN}/agent
+      - CONTROLLER_URL=${APPLICATION_DOMAIN}/dav
+      - ACAPY_AGENT_URL=${APPLICATION_DOMAIN}/agent/
     volumes:
       - ../dav-controller:/app:rw
       - ./dav-controller/proof_config_prod.yaml:/app/api/proof_config.yaml

--- a/docker/docker-compose-prod.yaml
+++ b/docker/docker-compose-prod.yaml
@@ -1,5 +1,24 @@
 version: "3"
 services:
+  reverse-proxy:
+    build:
+      context: ..
+      dockerfile: docker/Caddy/Dockerfile
+    environment:
+      - APPLICATION_DOMAIN=${APPLICATION_DOMAIN}
+      - CONTROLLER_HOST=controller
+      - CONTROLLER_PORT=5000
+      - AGENT_HOST=aca-py
+      - AGENT_PORT=8030
+      - CA_ENDPOINT=${CA_ENDPOINT:-https://acme-v02.api.letsencrypt.org/directory}
+    volumes:
+      - ./caddy/Caddyfile:/etc/caddy/Caddyfile
+    ports:
+      - ${HTTP_PORT:-80}:80
+      - ${HTTPS_PORT:-443}:443
+    networks:
+      - dav_controller
+
   controller:
     build:
       context: ..
@@ -17,13 +36,11 @@ services:
       - ACAPY_ADMIN_URL=http://aca-py:8077
       - ST_ACAPY_ADMIN_API_KEY_NAME=x-api-key
       - USE_OOB_PRESENT_PROOF=False
-      - DAV_PROOF_CONFIG_ID=${DAV_PROOF_CONFIG_ID}
+      - DAV_PROOF_CONFIG_ID=age-verification-bc-person-credential
       - ST_ACAPY_ADMIN_API_KEY=${AGENT_ADMIN_API_KEY}
       - DAV_CONTROLLER_DB_USER_PWD=${DAV_CONTROLLER_DB_PWD}
-      - CONTROLLER_URL=${CONTROLLER_URL}
-      - ACAPY_AGENT_URL=${AGENT_ENDPOINT}
-    ports:
-      - ${CONTROLLER_SERVICE_PORT}:5000
+      - CONTROLLER_URL=${APPLICATION_DOMAIN}/controller
+      - ACAPY_AGENT_URL=${APPLICATION_DOMAIN}/agent
     volumes:
       - ../dav-controller:/app:rw
       - ./dav-controller/proof_config_prod.yaml:/app/api/proof_config.yaml
@@ -60,13 +77,11 @@ services:
       - POSTGRESQL_WALLET_PORT=5432
       - POSTGRESQL_WALLET_USER=dav_agent
       - ACAPY_LABEL=${AGENT_NAME}
-      - ACAPY_ENDPOINT=${AGENT_ENDPOINT}
+      - ACAPY_ENDPOINT=${APPLICATION_DOMAIN}/agent
       - AGENT_ADMIN_API_KEY=${AGENT_ADMIN_API_KEY}
       - ACAPY_WALLET_KEY=${AGENT_WALLET_ENCRYPTION_KEY}
       - ACAPY_WALLET_SEED=${AGENT_WALLET_SEED}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
-    ports:
-      - ${AGENT_HTTP_PORT}:${AGENT_HTTP_PORT}
     networks:
       - dav_controller
     volumes:
@@ -77,7 +92,7 @@ services:
     command:
       [
         "-c",
-        'sleep 15; aca-py start --inbound-transport http ''0.0.0.0'' ${AGENT_HTTP_PORT} --outbound-transport http --wallet-storage-config ''{"url":"wallet-db:5432","max_connections":5}'' --wallet-storage-creds ''{"account":"dav_agent","password":"${POSTGRES_PASSWORD}","admin_account":"dav_agent","admin_password":"${POSTGRES_PASSWORD}"}'' --admin ''0.0.0.0'' 8077 --admin-api-key ${AGENT_ADMIN_API_KEY}',
+        'sleep 15; aca-py start --inbound-transport http ''0.0.0.0'' 8030 --outbound-transport http --wallet-storage-config ''{"url":"wallet-db:5432","max_connections":5}'' --wallet-storage-creds ''{"account":"dav_agent","password":"${POSTGRES_PASSWORD}","admin_account":"dav_agent","admin_password":"${POSTGRES_PASSWORD}"}'' --admin ''0.0.0.0'' 8077 --admin-api-key ${AGENT_ADMIN_API_KEY}',
       ]
 
   wallet-db:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -59,7 +59,7 @@ services:
       - dav_controller
 
   aca-py:
-    image: ghcr.io/hyperledger/aries-cloudagent-python:py3.9-0.11.0
+    image: ghcr.io/hyperledger/aries-cloudagent-python:py3.9-0.12.1
     environment:
       - ACAPY_LABEL=${AGENT_NAME}
       - ACAPY_ENDPOINT=${AGENT_ENDPOINT}

--- a/docs/Docker-for-Production.md
+++ b/docs/Docker-for-Production.md
@@ -25,3 +25,7 @@ To get started, follow these steps:
 
 To start from scratch and delete all existing containers and volumes, run the following command:
 `docker compose -f docker-compose-prod.yaml down -v`
+
+## Production CA Authority
+
+By default, the project is set-up to use LetsEncrypt Staging to obtain SSL certificates: when ready to run in production mode, uncomment the line specifying `CA_ENDPOINT` in the `.env` file and restart your services.

--- a/docs/Docker-for-Production.md
+++ b/docs/Docker-for-Production.md
@@ -21,6 +21,10 @@ To get started, follow these steps:
 4. Replace the values between angle braces in the `.env` file with values appropriate for your setup. The hard-coded values can be used to further customize the configuration, but they do not need to be changed. Remember to remove the braces when setting new values.
 5. Once everything is configured, running `docker compose -f docker-compose-prod.yaml up --build -d` should start the services and have them ready to accept requests.
 
+The application will be available at `https://your-domain.test/dav/`.
+
+A new `certs` folder holding the SSL certificates for the service will be created in the `docker/caddy` folder.
+
 ## Resetting the environment
 
 To start from scratch and delete all existing containers and volumes, run the following command:

--- a/docs/Docker-for-Production.md
+++ b/docs/Docker-for-Production.md
@@ -2,12 +2,13 @@
 
 This document outlines the steps to get a production-ready instance of the LCRB DAV service running in docker.
 
+Once running, the project will expose a service on ports `80` and `443`.
+
 ## Pre Requisites
 
 - Docker
-- A publicly-addressable URL pointing to the port defined by the `AGENT_HTTP_PORT` (8030 by default) on the target machine
-- The firewall must allow inbound/outbound traffic on the port defined by the `AGENT_HTTP_PORT` (8030 by default)
-- The firewall must allow inbound/outbound traffic on the port defined by the `CONTROLLER_SERVICE_PORT` (5000 by default)
+- A publicly-addressable URL pointing to the target machine.
+- The firewall must allow inbound/outbound traffic on the ports `80` (http) and `443` (https).
 - The firewall must allow outbound traffic on the port range 9700-9799 (this is to allow reading the Indy ledger)
 
 ## Getting Started
@@ -16,6 +17,11 @@ To get started, follow these steps:
 
 1. Clone the repository on the target machine
 2. Open a shell in the `docker` folder. Any shell should work, but a bash shell (such as Git Bash or WSL) is recommended
-3. Copy the `.env-example` file to a new file named `.env`: `cp .env-example .env`)
-4. Replace the values between angle braces in the `.env` file with values appropriate for your setup. The hard-coded values can be used to further customize the configuration, but they do not need to be changed.
-5. Once everything is configured, running `docker compose -f docker-compose-prod.yaml up` should start the services and have them ready to accept requests.
+3. Copy the `.env-example` file to a new file named `.env`: `cp .env-example .env`
+4. Replace the values between angle braces in the `.env` file with values appropriate for your setup. The hard-coded values can be used to further customize the configuration, but they do not need to be changed. Remember to remove the braces when setting new values.
+5. Once everything is configured, running `docker compose -f docker-compose-prod.yaml up --build -d` should start the services and have them ready to accept requests.
+
+## Resetting the environment
+
+To start from scratch and delete all existing containers and volumes, run the following command:
+`docker compose -f docker-compose-prod.yaml down -v`


### PR DESCRIPTION
Updated production mode to use a reverse proxy to route traffic to the services using a single URL/endpoint.

Caddy will route traffic to the `/agent` path to ACA-Py, and `/dav` to the controller.
Standard security headers as well as basic rate-limiting was added.

Caddy should take care of issuing SSL certificates using Letsencrypt, however I was unable to test end-to-end since ngrok appears to take over the process and interferes with the resolution of the challenge - might need help validating this.

Instructions have been updated and simplified to only expose and require customization of necessary parameters - all standard values have been set in `docker-compose-prod.yaml`.